### PR TITLE
Update Travis CI File

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
+dist: jammy
+
 language: node_js
 
 node_js:
 - 16
+- 18
+- 20
 
 cache:
   npm: false
 
 before_install:
-- npm i -g npm@8
-- npm --version
-
-install:
-# - npm ci --legacy-peer-deps
-- npm ci
+  - npm i -g npm@8
+  - npm --version
 
 script:
 - npm run build
@@ -20,11 +20,10 @@ script:
 - npm run lint
 - npm run check-packages
 
-# To enable semantic-release, uncomment this section.
 deploy:
 - provider: script
   skip_cleanup: true
   script: npx semantic-release
   on:
-    node: 16
-    branch: master
+    node: 20
+    branch: main

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ deploy:
   script: npx semantic-release
   on:
     node: 20
-    branch: main
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ deploy:
   skip_cleanup: true
   script: npx semantic-release
   on:
-    node: 14
+    node: 16
     branch: master


### PR DESCRIPTION
Updating the TravisCI YAML file in to bring it up to date with [other IBM SDK repos](https://github.com/IBM/platform-services-node-sdk/blob/main/.travis.yml). TravisCI file will now run on node versions 16,18 and 20, and build releases on node 20. 