### PR TITLE
fix(build): Regenerate the nodeJS sdk with the KMIP APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
+dist: jammy
+
 language: node_js
 
 node_js:
 - 16
+- 18
+- 20
 
 cache:
   npm: false
 
 before_install:
-- npm i -g npm@8
-- npm --version
-
-install:
-# - npm ci --legacy-peer-deps
-- npm ci
+  - npm i -g npm@8
+  - npm --version
 
 script:
 - npm run build
@@ -20,11 +20,10 @@ script:
 - npm run lint
 - npm run check-packages
 
-# To enable semantic-release, uncomment this section.
 deploy:
 - provider: script
   skip_cleanup: true
   script: npx semantic-release
   on:
-    node: 16
-    branch: master
+    node: 20
+    branch: main

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ deploy:
   script: npx semantic-release
   on:
     node: 20
-    branch: main
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ deploy:
   skip_cleanup: true
   script: npx semantic-release
   on:
-    node: 14
+    node: 16
     branch: master

--- a/ibm-key-protect-api/v2.ts
+++ b/ibm-key-protect-api/v2.ts
@@ -26,12 +26,12 @@ import { IncomingHttpHeaders, OutgoingHttpHeaders } from 'http';
 import {
   Authenticator,
   BaseService,
-  SDKLogger,
-  UserOptions,
   constructServiceUrl,
   getAuthenticatorFromEnvironment,
   getNewLogger,
   getQueryParam,
+  SDKLogger,
+  UserOptions,
   validateParams,
 } from 'ibm-cloud-sdk-core';
 import { getSdkHeaders } from '../lib/common';
@@ -54,10 +54,6 @@ class IbmKeyProtectApiV2 extends BaseService {
   static DEFAULT_SERVICE_NAME: string = 'ibm_key_protect_api';
 
   static PARAMETERIZED_SERVICE_URL: string = 'https://{region}.kms.cloud.ibm.com';
-
-  private static defaultUrlVariables = new Map([
-    ['region', 'us-south'],
-  ]);
 
   /**
    * Constructs a service URL by formatting the parameterized service URL.
@@ -111,6 +107,10 @@ class IbmKeyProtectApiV2 extends BaseService {
     }
     return service;
   }
+
+  private static defaultUrlVariables = new Map([
+    ['region', 'us-south'],
+  ]);
 
   /**
    * Construct a IbmKeyProtectApiV2 object.

--- a/ibm-key-protect-api/v2.ts
+++ b/ibm-key-protect-api/v2.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2023.
+ * (C) Copyright IBM Corp. 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
  * IBM OpenAPI SDK Code Generator Version: 3.78.0-67aec9b7-20230818-174940
  */
 
-/* eslint max-classes-per-file */
+/* eslint-disable max-classes-per-file */
 /* eslint-disable no-await-in-loop */
 
 import * as extend from 'extend';
@@ -26,12 +26,12 @@ import { IncomingHttpHeaders, OutgoingHttpHeaders } from 'http';
 import {
   Authenticator,
   BaseService,
+  SDKLogger,
+  UserOptions,
   constructServiceUrl,
   getAuthenticatorFromEnvironment,
   getNewLogger,
   getQueryParam,
-  SDKLogger,
-  UserOptions,
   validateParams,
 } from 'ibm-cloud-sdk-core';
 import { getSdkHeaders } from '../lib/common';
@@ -54,6 +54,10 @@ class IbmKeyProtectApiV2 extends BaseService {
   static DEFAULT_SERVICE_NAME: string = 'ibm_key_protect_api';
 
   static PARAMETERIZED_SERVICE_URL: string = 'https://{region}.kms.cloud.ibm.com';
+
+  private static defaultUrlVariables = new Map([
+    ['region', 'us-south'],
+  ]);
 
   /**
    * Constructs a service URL by formatting the parameterized service URL.
@@ -107,10 +111,6 @@ class IbmKeyProtectApiV2 extends BaseService {
     }
     return service;
   }
-
-  private static defaultUrlVariables = new Map([
-    ['region', 'us-south'],
-  ]);
 
   /**
    * Construct a IbmKeyProtectApiV2 object.
@@ -519,6 +519,485 @@ class IbmKeyProtectApiV2 extends BaseService {
             'Bluemix-Instance': _params.bluemixInstance,
             'Correlation-Id': _params.correlationId,
             'X-Kms-Key-Ring': _params.xKmsKeyRing,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+  /*************************
+   * kMIPAdapters
+   ************************/
+
+  /**
+   * List KMIP Adapters.
+   *
+   * List all the KMIP Adapters in the kms instance.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.bluemixInstance - The IBM Cloud instance ID that identifies your Key Protect service
+   * instance.
+   * @param {string} [params.correlationId] - The v4 UUID used to correlate and track transactions.
+   * @param {number} [params.limit] - The number of KMIP Adapters to retrieve. By default, `GET /kmip_adapters` returns
+   * the first 100 KMIP Adapters. To retrieve a different set of KMIP adapters, use `limit` with `offset` to page
+   * through your available resources. The maximum value for `limit` is 5000.
+   * **Usage:** If you have 20 KMIP Adapters, and you want to retrieve only the first 5 adapters, use
+   * `../kmip_adapters?limit=5`.
+   * @param {number} [params.offset] - The number of KMIP adapters to skip. By specifying `offset`, you retrieve a
+   * subset of KMIP adapters that starts with the `offset` value. Use `offset` with `limit` to page through your
+   * available resources.
+   * **Usage:** If you have 20 KMIP Adapters, and you want to retrieve adapters 11 through 15, use
+   * `../kmip_adapters?offset=10&limit=5`.
+   * @param {boolean} [params.totalCount] - If set to `true`, returns `totalCount` in the response metadata for use with
+   * pagination. The `totalCount` value returned specifies the total number of kmip adapters that match the request,
+   * disregarding limit and offset. The default is set to false.
+   * **Usage:** To return the `totalCount` value for use with pagination, use `../kmip_adapters?totalCount=true`.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.ListKMIPAdaptersWithTotalCount>>}
+   */
+  public getKmipAdapters(
+    params: IbmKeyProtectApiV2.GetKmipAdaptersParams
+  ): Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.ListKMIPAdaptersWithTotalCount>> {
+    const _params = { ...params };
+    const _requiredParams = ['bluemixInstance'];
+    const _validParams = ['bluemixInstance', 'correlationId', 'limit', 'offset', 'totalCount', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'limit': _params.limit,
+      'offset': _params.offset,
+      'totalCount': _params.totalCount,
+    };
+
+    const sdkHeaders = getSdkHeaders(IbmKeyProtectApiV2.DEFAULT_SERVICE_NAME, 'v2', 'getKmipAdapters');
+
+    const parameters = {
+      options: {
+        url: '/api/v2/kmip_adapters',
+        method: 'GET',
+        qs: query,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Bluemix-Instance': _params.bluemixInstance,
+            'Correlation-Id': _params.correlationId,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Create a KMIP Adapter.
+   *
+   * Create a KMIP adapter in a kms instance.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.bluemixInstance - The IBM Cloud instance ID that identifies your Key Protect service
+   * instance.
+   * @param {CollectionMetadata} params.metadata - The metadata that describes the resource array.
+   * @param {CreateKMIPAdapterRequestBodyResourcesItem[]} params.resources - A collection of resources.
+   * @param {string} [params.correlationId] - The v4 UUID used to correlate and track transactions.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.ListKMIPAdapters>>}
+   */
+  public createKmipAdapter(
+    params: IbmKeyProtectApiV2.CreateKmipAdapterParams
+  ): Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.ListKMIPAdapters>> {
+    const _params = { ...params };
+    const _requiredParams = ['bluemixInstance', 'metadata', 'resources'];
+    const _validParams = ['bluemixInstance', 'metadata', 'resources', 'correlationId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'metadata': _params.metadata,
+      'resources': _params.resources,
+    };
+
+    const sdkHeaders = getSdkHeaders(IbmKeyProtectApiV2.DEFAULT_SERVICE_NAME, 'v2', 'createKmipAdapter');
+
+    const parameters = {
+      options: {
+        url: '/api/v2/kmip_adapters',
+        method: 'POST',
+        body,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Bluemix-Instance': _params.bluemixInstance,
+            'Correlation-Id': _params.correlationId,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Retrieve a KMIP Adapter.
+   *
+   * Retrieve a KMIP adapter using its ID / name and get its full details.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.bluemixInstance - The IBM Cloud instance ID that identifies your Key Protect service
+   * instance.
+   * @param {string} params.id - The name or v4 UUID of the KMIP Adapter that uniquely identifies it.
+   * @param {string} [params.correlationId] - The v4 UUID used to correlate and track transactions.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.ListKMIPAdapters>>}
+   */
+  public getKmipAdapter(
+    params: IbmKeyProtectApiV2.GetKmipAdapterParams
+  ): Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.ListKMIPAdapters>> {
+    const _params = { ...params };
+    const _requiredParams = ['bluemixInstance', 'id'];
+    const _validParams = ['bluemixInstance', 'id', 'correlationId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(IbmKeyProtectApiV2.DEFAULT_SERVICE_NAME, 'v2', 'getKmipAdapter');
+
+    const parameters = {
+      options: {
+        url: '/api/v2/kmip_adapters/{id}',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Bluemix-Instance': _params.bluemixInstance,
+            'Correlation-Id': _params.correlationId,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Delete a KMIP Adapter.
+   *
+   * Delete a KMIP Adapter with the given ID / name.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.bluemixInstance - The IBM Cloud instance ID that identifies your Key Protect service
+   * instance.
+   * @param {string} params.id - The name or v4 UUID of the KMIP Adapter that uniquely identifies it.
+   * @param {string} [params.correlationId] - The v4 UUID used to correlate and track transactions.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.EmptyObject>>}
+   */
+  public deleteKmipAdapter(
+    params: IbmKeyProtectApiV2.DeleteKmipAdapterParams
+  ): Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.EmptyObject>> {
+    const _params = { ...params };
+    const _requiredParams = ['bluemixInstance', 'id'];
+    const _validParams = ['bluemixInstance', 'id', 'correlationId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(IbmKeyProtectApiV2.DEFAULT_SERVICE_NAME, 'v2', 'deleteKmipAdapter');
+
+    const parameters = {
+      options: {
+        url: '/api/v2/kmip_adapters/{id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Bluemix-Instance': _params.bluemixInstance,
+            'Correlation-Id': _params.correlationId,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Get all client certificates.
+   *
+   * Get all client certificates in a KMIP Adapter.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.bluemixInstance - The IBM Cloud instance ID that identifies your Key Protect service
+   * instance.
+   * @param {string} params.adapterId - The name or v4 UUID of the KMIP Adapter that uniquely identifies it.
+   * @param {string} [params.correlationId] - The v4 UUID used to correlate and track transactions.
+   * @param {number} [params.limit] - The number of KMIP Certificates to retrieve. By default, `GET
+   * /kmip_adapters/{id}/certificates` returns the first 100 KMIP Certificates. To retrieve a different set of
+   * certificates, use `limit` with `offset` to page through your available resources. The maximum value for `limit` is
+   * 200.
+   * **Usage:** If you have 20 KMIP certificates associated with your KMIP adapter, and you want to retrieve only the
+   * first 5 certificates, use `../kmip_adapters/{id}/certificates?limit=5`.
+   * @param {number} [params.offset] - The number of KMIP Adapters to skip. By specifying `offset`, you retrieve a
+   * subset of certificates that starts with the `offset` value. Use `offset` with `limit` to page through your
+   * available resources.
+   * **Usage:** If you have 20 certificates associated with your KMIP adapter, and you want to retrieve certificates 11
+   * through 15, use `../kmip_adapters/{id}/certificates?offset=10&limit=5`.
+   * @param {boolean} [params.totalCount] - If set to `true`, returns `totalCount` in the response metadata for use with
+   * pagination. The `totalCount` value returned specifies the total number of kmip adapters that match the request,
+   * disregarding limit and offset. The default is set to false.
+   * **Usage:** To return the `totalCount` value for use with pagination, use
+   * `../kmip_adapters/{id}/certificates?totalCount=true`.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.ListKMIPPartialClientCertificatesWithTotalCount>>}
+   */
+  public getKmipClientCertificates(
+    params: IbmKeyProtectApiV2.GetKmipClientCertificatesParams
+  ): Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.ListKMIPPartialClientCertificatesWithTotalCount>> {
+    const _params = { ...params };
+    const _requiredParams = ['bluemixInstance', 'adapterId'];
+    const _validParams = ['bluemixInstance', 'adapterId', 'correlationId', 'limit', 'offset', 'totalCount', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'limit': _params.limit,
+      'offset': _params.offset,
+      'totalCount': _params.totalCount,
+    };
+
+    const path = {
+      'adapter_id': _params.adapterId,
+    };
+
+    const sdkHeaders = getSdkHeaders(IbmKeyProtectApiV2.DEFAULT_SERVICE_NAME, 'v2', 'getKmipClientCertificates');
+
+    const parameters = {
+      options: {
+        url: '/api/v2/kmip_adapters/{adapter_id}/certificates',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Bluemix-Instance': _params.bluemixInstance,
+            'Correlation-Id': _params.correlationId,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Add a client certificate to a KMIP Adapter.
+   *
+   * Add a Certificate to a KMIP Adapter. A maximum of 200 certificates can be associated with a KMIP Adapter at a time.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.bluemixInstance - The IBM Cloud instance ID that identifies your Key Protect service
+   * instance.
+   * @param {string} params.adapterId - The name or v4 UUID of the KMIP Adapter that uniquely identifies it.
+   * @param {CollectionMetadata} params.metadata - The metadata that describes the resource array.
+   * @param {CreateKMIPClientCertificateObject[]} params.resources - A collection of resources.
+   * @param {string} [params.correlationId] - The v4 UUID used to correlate and track transactions.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.ListKMIPClientCertificates>>}
+   */
+  public addKmipClientCertificate(
+    params: IbmKeyProtectApiV2.AddKmipClientCertificateParams
+  ): Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.ListKMIPClientCertificates>> {
+    const _params = { ...params };
+    const _requiredParams = ['bluemixInstance', 'adapterId', 'metadata', 'resources'];
+    const _validParams = ['bluemixInstance', 'adapterId', 'metadata', 'resources', 'correlationId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'metadata': _params.metadata,
+      'resources': _params.resources,
+    };
+
+    const path = {
+      'adapter_id': _params.adapterId,
+    };
+
+    const sdkHeaders = getSdkHeaders(IbmKeyProtectApiV2.DEFAULT_SERVICE_NAME, 'v2', 'addKmipClientCertificate');
+
+    const parameters = {
+      options: {
+        url: '/api/v2/kmip_adapters/{adapter_id}/certificates',
+        method: 'POST',
+        body,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Bluemix-Instance': _params.bluemixInstance,
+            'Correlation-Id': _params.correlationId,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Retrieve a client certificate from a KMIP Adapter.
+   *
+   * Retrieve a client certificate from a KMIP Adapter using its id / name.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.bluemixInstance - The IBM Cloud instance ID that identifies your Key Protect service
+   * instance.
+   * @param {string} params.adapterId - The name or v4 UUID of the KMIP Adapter that uniquely identifies it.
+   * @param {string} params.id - The name or v4 UUID of the KMIP Adapter Client Certificate that uniquely identifies it.
+   * @param {string} [params.correlationId] - The v4 UUID used to correlate and track transactions.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.ListKMIPClientCertificates>>}
+   */
+  public getKmipClientCertificate(
+    params: IbmKeyProtectApiV2.GetKmipClientCertificateParams
+  ): Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.ListKMIPClientCertificates>> {
+    const _params = { ...params };
+    const _requiredParams = ['bluemixInstance', 'adapterId', 'id'];
+    const _validParams = ['bluemixInstance', 'adapterId', 'id', 'correlationId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'adapter_id': _params.adapterId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(IbmKeyProtectApiV2.DEFAULT_SERVICE_NAME, 'v2', 'getKmipClientCertificate');
+
+    const parameters = {
+      options: {
+        url: '/api/v2/kmip_adapters/{adapter_id}/certificates/{id}',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Bluemix-Instance': _params.bluemixInstance,
+            'Correlation-Id': _params.correlationId,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Delete a client certificate from a KMIP Adapter.
+   *
+   * Remove a client certificate from a KMIP Adapter given its id / name.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.bluemixInstance - The IBM Cloud instance ID that identifies your Key Protect service
+   * instance.
+   * @param {string} params.adapterId - The name or v4 UUID of the KMIP Adapter that uniquely identifies it.
+   * @param {string} params.id - The name or v4 UUID of the KMIP Adapter Client Certificate that uniquely identifies it.
+   * @param {string} [params.correlationId] - The v4 UUID used to correlate and track transactions.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.EmptyObject>>}
+   */
+  public deleteKmipClientCertificate(
+    params: IbmKeyProtectApiV2.DeleteKmipClientCertificateParams
+  ): Promise<IbmKeyProtectApiV2.Response<IbmKeyProtectApiV2.EmptyObject>> {
+    const _params = { ...params };
+    const _requiredParams = ['bluemixInstance', 'adapterId', 'id'];
+    const _validParams = ['bluemixInstance', 'adapterId', 'id', 'correlationId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'adapter_id': _params.adapterId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(IbmKeyProtectApiV2.DEFAULT_SERVICE_NAME, 'v2', 'deleteKmipClientCertificate');
+
+    const parameters = {
+      options: {
+        url: '/api/v2/kmip_adapters/{adapter_id}/certificates/{id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Bluemix-Instance': _params.bluemixInstance,
+            'Correlation-Id': _params.correlationId,
           },
           _params.headers
         ),
@@ -3620,6 +4099,141 @@ namespace IbmKeyProtectApiV2 {
     headers?: OutgoingHttpHeaders;
   }
 
+  /** Parameters for the `getKmipAdapters` operation. */
+  export interface GetKmipAdaptersParams {
+    /** The IBM Cloud instance ID that identifies your Key Protect service instance. */
+    bluemixInstance: string;
+    /** The v4 UUID used to correlate and track transactions. */
+    correlationId?: string;
+    /** The number of KMIP Adapters to retrieve. By default, `GET /kmip_adapters` returns the first 100 KMIP
+     *  Adapters. To retrieve a different set of KMIP adapters, use `limit` with `offset` to page through your available
+     *  resources. The maximum value for `limit` is 5000.
+     *  **Usage:** If you have 20 KMIP Adapters, and you want to retrieve only the first 5 adapters, use
+     *  `../kmip_adapters?limit=5`.
+     */
+    limit?: number;
+    /** The number of KMIP adapters to skip. By specifying `offset`, you retrieve a subset of KMIP adapters that
+     *  starts with the `offset` value. Use `offset` with `limit` to page through your available resources.
+     *  **Usage:** If you have 20 KMIP Adapters, and you want to retrieve adapters 11 through 15, use
+     *  `../kmip_adapters?offset=10&limit=5`.
+     */
+    offset?: number;
+    /** If set to `true`, returns `totalCount` in the response metadata for use with pagination. The `totalCount`
+     *  value returned specifies the total number of kmip adapters that match the request, disregarding limit and
+     *  offset. The default is set to false.
+     *  **Usage:** To return the `totalCount` value for use with pagination, use `../kmip_adapters?totalCount=true`.
+     */
+    totalCount?: boolean;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `createKmipAdapter` operation. */
+  export interface CreateKmipAdapterParams {
+    /** The IBM Cloud instance ID that identifies your Key Protect service instance. */
+    bluemixInstance: string;
+    /** The metadata that describes the resource array. */
+    metadata: CollectionMetadata;
+    /** A collection of resources. */
+    resources: CreateKMIPAdapterRequestBodyResourcesItem[];
+    /** The v4 UUID used to correlate and track transactions. */
+    correlationId?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `getKmipAdapter` operation. */
+  export interface GetKmipAdapterParams {
+    /** The IBM Cloud instance ID that identifies your Key Protect service instance. */
+    bluemixInstance: string;
+    /** The name or v4 UUID of the KMIP Adapter that uniquely identifies it. */
+    id: string;
+    /** The v4 UUID used to correlate and track transactions. */
+    correlationId?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `deleteKmipAdapter` operation. */
+  export interface DeleteKmipAdapterParams {
+    /** The IBM Cloud instance ID that identifies your Key Protect service instance. */
+    bluemixInstance: string;
+    /** The name or v4 UUID of the KMIP Adapter that uniquely identifies it. */
+    id: string;
+    /** The v4 UUID used to correlate and track transactions. */
+    correlationId?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `getKmipClientCertificates` operation. */
+  export interface GetKmipClientCertificatesParams {
+    /** The IBM Cloud instance ID that identifies your Key Protect service instance. */
+    bluemixInstance: string;
+    /** The name or v4 UUID of the KMIP Adapter that uniquely identifies it. */
+    adapterId: string;
+    /** The v4 UUID used to correlate and track transactions. */
+    correlationId?: string;
+    /** The number of KMIP Certificates to retrieve. By default, `GET /kmip_adapters/{id}/certificates` returns the
+     *  first 100 KMIP Certificates. To retrieve a different set of certificates, use `limit` with `offset` to page
+     *  through your available resources. The maximum value for `limit` is 200.
+     *  **Usage:** If you have 20 KMIP certificates associated with your KMIP adapter, and you want to retrieve only the
+     *  first 5 certificates, use `../kmip_adapters/{id}/certificates?limit=5`.
+     */
+    limit?: number;
+    /** The number of KMIP Adapters to skip. By specifying `offset`, you retrieve a subset of certificates that
+     *  starts with the `offset` value. Use `offset` with `limit` to page through your available resources.
+     *  **Usage:** If you have 20 certificates associated with your KMIP adapter, and you want to retrieve certificates
+     *  11 through 15, use `../kmip_adapters/{id}/certificates?offset=10&limit=5`.
+     */
+    offset?: number;
+    /** If set to `true`, returns `totalCount` in the response metadata for use with pagination. The `totalCount`
+     *  value returned specifies the total number of kmip adapters that match the request, disregarding limit and
+     *  offset. The default is set to false.
+     *  **Usage:** To return the `totalCount` value for use with pagination, use
+     *  `../kmip_adapters/{id}/certificates?totalCount=true`.
+     */
+    totalCount?: boolean;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `addKmipClientCertificate` operation. */
+  export interface AddKmipClientCertificateParams {
+    /** The IBM Cloud instance ID that identifies your Key Protect service instance. */
+    bluemixInstance: string;
+    /** The name or v4 UUID of the KMIP Adapter that uniquely identifies it. */
+    adapterId: string;
+    /** The metadata that describes the resource array. */
+    metadata: CollectionMetadata;
+    /** A collection of resources. */
+    resources: CreateKMIPClientCertificateObject[];
+    /** The v4 UUID used to correlate and track transactions. */
+    correlationId?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `getKmipClientCertificate` operation. */
+  export interface GetKmipClientCertificateParams {
+    /** The IBM Cloud instance ID that identifies your Key Protect service instance. */
+    bluemixInstance: string;
+    /** The name or v4 UUID of the KMIP Adapter that uniquely identifies it. */
+    adapterId: string;
+    /** The name or v4 UUID of the KMIP Adapter Client Certificate that uniquely identifies it. */
+    id: string;
+    /** The v4 UUID used to correlate and track transactions. */
+    correlationId?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `deleteKmipClientCertificate` operation. */
+  export interface DeleteKmipClientCertificateParams {
+    /** The IBM Cloud instance ID that identifies your Key Protect service instance. */
+    bluemixInstance: string;
+    /** The name or v4 UUID of the KMIP Adapter that uniquely identifies it. */
+    adapterId: string;
+    /** The name or v4 UUID of the KMIP Adapter Client Certificate that uniquely identifies it. */
+    id: string;
+    /** The v4 UUID used to correlate and track transactions. */
+    correlationId?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
   /** Parameters for the `wrapKey` operation. */
   export interface WrapKeyParams {
     /** The v4 UUID or alias that uniquely identifies the key. */
@@ -4989,6 +5603,44 @@ namespace IbmKeyProtectApiV2 {
     totalCount?: number;
   }
 
+  /** CreateKMIPAdapterRequestBodyResourcesItem. */
+  export interface CreateKMIPAdapterRequestBodyResourcesItem {
+    /** A human-readable name of the KMIP adapter unique within the kms instance. If one is not specified, one will
+     *  be autogenerated of the format `kmip_adapter_<timestamp>_<random_string>`. To protect your privacy do not use
+     *  personal data, such as your name or location, as a name for your KMIP adapter. The name must be  alphanumeric
+     *  and cannot contain spaces or special characters other than `-` or `_`. The name cannot be a UUID and must not be
+     *  a Key Protect reserved name: `allowed_ip`, `certificate`, `certificates`,`key`,`keys`, `metadata`, `policy`,
+     *  `policies`, `registration`, `registrations`, `ring`, `rings`, `rotate`, `wrap`, `unwrap`, `rewrap`, `version`,
+     *  `versions`.
+     */
+    name?: string;
+    /** The optional description of the KMIP adapter. The maximum length is 240 characters. To protect your privacy,
+     *  do not use personal data, such as your name or location, as a description for your KMIP adapter.
+     */
+    description?: string;
+    /** The profile of KMIP adapter to be created. */
+    profile?: string;
+    /** The data specific to the KMIP Adapter profile. This is a required field for type `native_1.0`. */
+    profile_data?: KMIPProfileDataBody;
+  }
+
+  /** CreateKMIPClientCertificateObject. */
+  export interface CreateKMIPClientCertificateObject {
+    /** The client certificate to be associated with the KMIP Adapter. It should explicitly have the BEGIN
+     *  CERTIFICATE and END CERTIFICATE tags.
+     */
+    certificate: string;
+    /** A human-readable name that uniquely identifies a certificate within the given adapter. If one is  not
+     *  specified, one will be autogenerated of the format `kmip_certificate_<timestamp>_<random_string>`. To protect
+     *  your privacy do not use personal data, such as your name or location, as a name for your client certificate. The
+     *  name must be  alphanumeric and cannot contain spaces or special characters other than `-` or `_`. The name
+     *  cannot be a UUID and must not be a Key Protect reserved name: `allowed_ip`, `key`,`keys`, `metadata`, `policy`,
+     *  `policies`, `registration`, `registrations`, `ring`, `rings`, `rotate`, `wrap`, `unwrap`, `rewrap`, `version`,
+     *  `versions`.
+     */
+    name?: string;
+  }
+
   /** The schema for the resources object in the body of a create Migration Intent. */
   export interface CreateMigrationIntentObject {
     /** The CRN of the Customer Root Key (CRK) which is the target of the migration. */
@@ -5580,6 +6232,97 @@ namespace IbmKeyProtectApiV2 {
     attributes?: RotationProperties;
   }
 
+  /** Properties applicable to all KMIP adapter resources. */
+  export interface KMIPAdapter {
+    /** The v4 UUID that uniquely identifies this KMIP adapter. */
+    id?: string;
+    /** A human-readable name of the KMIP adapter unique within the kms instance. If one is not specified, one will
+     *  be autogenerated of the format `kmip_adapter_<timestamp>_<random_string>`. To protect your privacy do not use
+     *  personal data, such as your name or location, as a name for your KMIP adapter. The name must be  alphanumeric
+     *  and cannot contain spaces or special characters other than `-` or `_`. The name cannot be a UUID and must not be
+     *  a Key Protect reserved name: `allowed_ip`, `certificate`, `certificates`,`key`,`keys`, `metadata`, `policy`,
+     *  `policies`, `registration`, `registrations`, `ring`, `rings`, `rotate`, `wrap`, `unwrap`, `rewrap`, `version`,
+     *  `versions`.
+     */
+    name?: string;
+    /** The date the KMIP adapter was created. The date format follows RFC 3339. */
+    created_at?: string;
+    /** The unique identifier of the user that created the KMIP adapter. */
+    created_by?: string;
+    /** The date the KMIP adapter was last modified, either by creation or by modification  of adapter subresources.
+     *  The date format follows RFC 3339.
+     */
+    updated_at?: string;
+    /** The unique identifier of the user that updated the KMIP adapter. */
+    updated_by?: string;
+    /** The profile of KMIP adapter to be created. */
+    profile?: string;
+    /** The optional description of the KMIP adapter. The maximum length is 240 characters. To protect your privacy,
+     *  do not use personal data, such as your name or location, as a description for your KMIP adapter.
+     */
+    description?: string;
+    /** Properties that must be specified to profile_data when it is of native_1.0 KMIP adapter resource. */
+    profile_data?: KMIPProfileDataNative;
+  }
+
+  /** Properties of a client certificate. */
+  export interface KMIPClientCertificate {
+    /** A human-readable name that uniquely identifies a certificate within the given adapter. If one is  not
+     *  specified, one will be autogenerated of the format `kmip_certificate_<timestamp>_<random_string>`. To protect
+     *  your privacy do not use personal data, such as your name or location, as a name for your client certificate. The
+     *  name must be  alphanumeric and cannot contain spaces or special characters other than `-` or `_`. The name
+     *  cannot be a UUID and must not be a Key Protect reserved name: `allowed_ip`, `key`,`keys`, `metadata`, `policy`,
+     *  `policies`, `registration`, `registrations`, `ring`, `rings`, `rotate`, `wrap`, `unwrap`, `rewrap`, `version`,
+     *  `versions`.
+     */
+    name?: string;
+    /** The v4 UUID that uniquely identifies this certificate resource. */
+    id?: string;
+    /** The date this certificate resource was created on the KMIP Adapter. The date format follows RFC 3339. */
+    created_at?: string;
+    /** The IAM id that created the certificate resource. */
+    created_by?: string;
+    /** The client certificate to be associated with the KMIP Adapter. It should explicitly have the BEGIN
+     *  CERTIFICATE and END CERTIFICATE tags.
+     */
+    certificate?: string;
+  }
+
+  /** Partial properties of a client certificate. */
+  export interface KMIPClientPartialCertificate {
+    /** A human-readable name that uniquely identifies a certificate within the given adapter. If one is  not
+     *  specified, one will be autogenerated of the format `kmip_certificate_<timestamp>_<random_string>`. To protect
+     *  your privacy do not use personal data, such as your name or location, as a name for your client certificate. The
+     *  name must be  alphanumeric and cannot contain spaces or special characters other than `-` or `_`. The name
+     *  cannot be a UUID and must not be a Key Protect reserved name: `allowed_ip`, `key`,`keys`, `metadata`, `policy`,
+     *  `policies`, `registration`, `registrations`, `ring`, `rings`, `rotate`, `wrap`, `unwrap`, `rewrap`, `version`,
+     *  `versions`.
+     */
+    name?: string;
+    /** The v4 UUID that uniquely identifies this certificate resource. */
+    id?: string;
+    /** The date this certificate resource was created on the KMIP Adapter. The date format follows RFC 3339. */
+    created_at?: string;
+    /** The IAM id that created the certificate resource. */
+    created_by?: string;
+  }
+
+  /** The data specific to the KMIP Adapter profile. This is a required field for type `native_1.0`. */
+  export interface KMIPProfileDataBody {
+  }
+
+  /** Properties that must be specified to profile_data when it is of native_1.0 KMIP adapter resource. */
+  export interface KMIPProfileDataNative {
+    /** An ID that identifies the Customer Root Key(CRK) to be used. This CRK must exist in the same kms instance as
+     *  the adapter.
+     */
+    crk_id: string;
+    /** The unique identifier of the key ring to be used for creating standard keys in the kms instance. When this
+     *  is not specified, the `default` key ring will be used.
+     */
+    target_key_ring_id?: string;
+  }
+
   /** Properties associated with a key response. */
   export interface Key {
     metadata?: CollectionMetadataOneOf;
@@ -5940,6 +6683,36 @@ namespace IbmKeyProtectApiV2 {
 
   /** ListCollectionMetadata. */
   export interface ListCollectionMetadata {
+  }
+
+  /** The base schema for listing kmip adapter. */
+  export interface ListKMIPAdapters {
+    metadata?: ListCollectionMetadata;
+    /** A collection of resources. */
+    resources?: KMIPAdapter[];
+  }
+
+  /** The base schema for listing kmip adapter with total count. */
+  export interface ListKMIPAdaptersWithTotalCount {
+    /** The metadata that describes the resource array. */
+    metadata: CollectionMetadataWithTotalCount;
+    /** A collection of resources. */
+    resources?: KMIPAdapter[];
+  }
+
+  /** The base schema for listing kmip client certificates in a kmip adapter. */
+  export interface ListKMIPClientCertificates {
+    metadata?: ListCollectionMetadata;
+    /** A collection of resources. */
+    resources?: KMIPClientCertificate[];
+  }
+
+  /** The base schema for listing kmip client certificates in a kmip adapter with total count. */
+  export interface ListKMIPPartialClientCertificatesWithTotalCount {
+    /** The metadata that describes the resource array. */
+    metadata: CollectionMetadataWithTotalCount;
+    /** A collection of resources. */
+    resources?: KMIPClientPartialCertificate[];
   }
 
   /** The base schema for listing key rings. */
@@ -6473,6 +7246,18 @@ namespace IbmKeyProtectApiV2 {
     metadata: CollectionMetadata;
     /** A collection of resources. */
     resources: GetMultipleKeyPoliciesResource[];
+  }
+
+  /** Properties that must be specified to profile_data when it is of native_1.0 KMIP adapter resource. */
+  export interface KMIPProfileDataBodyKMIPProfileDataNative extends KMIPProfileDataBody {
+    /** An ID that identifies the Customer Root Key(CRK) to be used. This CRK must exist in the same kms instance as
+     *  the adapter.
+     */
+    crk_id: string;
+    /** The unique identifier of the key ring to be used for creating standard keys in the kms instance. When this
+     *  is not specified, the `default` key ring will be used.
+     */
+    target_key_ring_id?: string;
   }
 
   /** Properties that are associated with the response body of an rewrap action. */

--- a/test/unit/ibm-key-protect-api.v2.unit.test.js
+++ b/test/unit/ibm-key-protect-api.v2.unit.test.js
@@ -24,13 +24,8 @@ const sdkCorePackage = require('ibm-cloud-sdk-core');
 const { NoAuthAuthenticator, unitTestUtils } = sdkCorePackage;
 const IbmKeyProtectApiV2 = require('../../dist/ibm-key-protect-api/v2');
 
-const {
-  getOptions,
-  checkUrlAndMethod,
-  checkMediaHeaders,
-  expectToBePromise,
-  checkUserHeader,
-} = unitTestUtils;
+const { getOptions, checkUrlAndMethod, checkMediaHeaders, expectToBePromise, checkUserHeader } =
+  unitTestUtils;
 
 const ibmKeyProtectApiServiceOptions = {
   authenticator: new NoAuthAuthenticator(),
@@ -349,7 +344,8 @@ describe('IbmKeyProtectApiV2', () => {
           instanceId,
         };
 
-        const cryptoV2GetInstanceEndpointsResult = ibmKeyProtectApiService.cryptoV2GetInstanceEndpoints(cryptoV2GetInstanceEndpointsParams);
+        const cryptoV2GetInstanceEndpointsResult =
+          ibmKeyProtectApiService.cryptoV2GetInstanceEndpoints(cryptoV2GetInstanceEndpointsParams);
 
         // all methods should return a Promise
         expectToBePromise(cryptoV2GetInstanceEndpointsResult);
@@ -447,7 +443,8 @@ describe('IbmKeyProtectApiV2', () => {
           offset,
         };
 
-        const getGovernanceConfigResult = ibmKeyProtectApiService.getGovernanceConfig(getGovernanceConfigParams);
+        const getGovernanceConfigResult =
+          ibmKeyProtectApiService.getGovernanceConfig(getGovernanceConfigParams);
 
         // all methods should return a Promise
         expectToBePromise(getGovernanceConfigResult);
@@ -546,7 +543,7 @@ describe('IbmKeyProtectApiV2', () => {
 
       beforeEach(() => {
         unmock_createRequest();
-        const scope = nock(serviceUrl)
+        nock(serviceUrl)
           .get((uri) => uri.includes(path))
           .reply(200, mockPagerResponse1)
           .get((uri) => uri.includes(path))
@@ -569,7 +566,10 @@ describe('IbmKeyProtectApiV2', () => {
           limit: 10,
         };
         const allResults = [];
-        const pager = new IbmKeyProtectApiV2.GetGovernanceConfigPager(ibmKeyProtectApiService, params);
+        const pager = new IbmKeyProtectApiV2.GetGovernanceConfigPager(
+          ibmKeyProtectApiService,
+          params
+        );
         while (pager.hasNext()) {
           const nextPage = await pager.getNext();
           expect(nextPage).not.toBeNull();
@@ -589,7 +589,10 @@ describe('IbmKeyProtectApiV2', () => {
           transactionId: 'testString',
           limit: 10,
         };
-        const pager = new IbmKeyProtectApiV2.GetGovernanceConfigPager(ibmKeyProtectApiService, params);
+        const pager = new IbmKeyProtectApiV2.GetGovernanceConfigPager(
+          ibmKeyProtectApiService,
+          params
+        );
         const allResults = await pager.getAll();
         expect(allResults).not.toBeNull();
         expect(allResults).toHaveLength(2);
@@ -614,7 +617,8 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const postImportTokenResult = ibmKeyProtectApiService.postImportToken(postImportTokenParams);
+        const postImportTokenResult =
+          ibmKeyProtectApiService.postImportToken(postImportTokenParams);
 
         // all methods should return a Promise
         expectToBePromise(postImportTokenResult);
@@ -800,7 +804,8 @@ describe('IbmKeyProtectApiV2', () => {
           totalCount,
         };
 
-        const getKmipAdaptersResult = ibmKeyProtectApiService.getKmipAdapters(getKmipAdaptersParams);
+        const getKmipAdaptersResult =
+          ibmKeyProtectApiService.getKmipAdapters(getKmipAdaptersParams);
 
         // all methods should return a Promise
         expectToBePromise(getKmipAdaptersResult);
@@ -916,7 +921,8 @@ describe('IbmKeyProtectApiV2', () => {
           correlationId,
         };
 
-        const createKmipAdapterResult = ibmKeyProtectApiService.createKmipAdapter(createKmipAdapterParams);
+        const createKmipAdapterResult =
+          ibmKeyProtectApiService.createKmipAdapter(createKmipAdapterParams);
 
         // all methods should return a Promise
         expectToBePromise(createKmipAdapterResult);
@@ -1103,7 +1109,8 @@ describe('IbmKeyProtectApiV2', () => {
           correlationId,
         };
 
-        const deleteKmipAdapterResult = ibmKeyProtectApiService.deleteKmipAdapter(deleteKmipAdapterParams);
+        const deleteKmipAdapterResult =
+          ibmKeyProtectApiService.deleteKmipAdapter(deleteKmipAdapterParams);
 
         // all methods should return a Promise
         expectToBePromise(deleteKmipAdapterResult);
@@ -1201,7 +1208,9 @@ describe('IbmKeyProtectApiV2', () => {
           totalCount,
         };
 
-        const getKmipClientCertificatesResult = ibmKeyProtectApiService.getKmipClientCertificates(getKmipClientCertificatesParams);
+        const getKmipClientCertificatesResult = ibmKeyProtectApiService.getKmipClientCertificates(
+          getKmipClientCertificatesParams
+        );
 
         // all methods should return a Promise
         expectToBePromise(getKmipClientCertificatesResult);
@@ -1211,7 +1220,11 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(mockRequestOptions, '/api/v2/kmip_adapters/{adapter_id}/certificates', 'GET');
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/api/v2/kmip_adapters/{adapter_id}/certificates',
+          'GET'
+        );
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -1314,7 +1327,9 @@ describe('IbmKeyProtectApiV2', () => {
           correlationId,
         };
 
-        const addKmipClientCertificateResult = ibmKeyProtectApiService.addKmipClientCertificate(addKmipClientCertificateParams);
+        const addKmipClientCertificateResult = ibmKeyProtectApiService.addKmipClientCertificate(
+          addKmipClientCertificateParams
+        );
 
         // all methods should return a Promise
         expectToBePromise(addKmipClientCertificateResult);
@@ -1324,7 +1339,11 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(mockRequestOptions, '/api/v2/kmip_adapters/{adapter_id}/certificates', 'POST');
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/api/v2/kmip_adapters/{adapter_id}/certificates',
+          'POST'
+        );
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -1414,7 +1433,9 @@ describe('IbmKeyProtectApiV2', () => {
           correlationId,
         };
 
-        const getKmipClientCertificateResult = ibmKeyProtectApiService.getKmipClientCertificate(getKmipClientCertificateParams);
+        const getKmipClientCertificateResult = ibmKeyProtectApiService.getKmipClientCertificate(
+          getKmipClientCertificateParams
+        );
 
         // all methods should return a Promise
         expectToBePromise(getKmipClientCertificateResult);
@@ -1424,7 +1445,11 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(mockRequestOptions, '/api/v2/kmip_adapters/{adapter_id}/certificates/{id}', 'GET');
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/api/v2/kmip_adapters/{adapter_id}/certificates/{id}',
+          'GET'
+        );
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -1511,7 +1536,8 @@ describe('IbmKeyProtectApiV2', () => {
           correlationId,
         };
 
-        const deleteKmipClientCertificateResult = ibmKeyProtectApiService.deleteKmipClientCertificate(deleteKmipClientCertificateParams);
+        const deleteKmipClientCertificateResult =
+          ibmKeyProtectApiService.deleteKmipClientCertificate(deleteKmipClientCertificateParams);
 
         // all methods should return a Promise
         expectToBePromise(deleteKmipClientCertificateResult);
@@ -1521,7 +1547,11 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(mockRequestOptions, '/api/v2/kmip_adapters/{adapter_id}/certificates/{id}', 'DELETE');
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/api/v2/kmip_adapters/{adapter_id}/certificates/{id}',
+          'DELETE'
+        );
         const expectedAccept = undefined;
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -2007,7 +2037,8 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const setKeyForDeletionResult = ibmKeyProtectApiService.setKeyForDeletion(setKeyForDeletionParams);
+        const setKeyForDeletionResult =
+          ibmKeyProtectApiService.setKeyForDeletion(setKeyForDeletionParams);
 
         // all methods should return a Promise
         expectToBePromise(setKeyForDeletionResult);
@@ -2017,7 +2048,11 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(mockRequestOptions, '/api/v2/keys/{id}/actions/setKeyForDeletion', 'POST');
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/api/v2/keys/{id}/actions/setKeyForDeletion',
+          'POST'
+        );
         const expectedAccept = undefined;
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -2102,7 +2137,8 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const unsetKeyForDeletionResult = ibmKeyProtectApiService.unsetKeyForDeletion(unsetKeyForDeletionParams);
+        const unsetKeyForDeletionResult =
+          ibmKeyProtectApiService.unsetKeyForDeletion(unsetKeyForDeletionParams);
 
         // all methods should return a Promise
         expectToBePromise(unsetKeyForDeletionResult);
@@ -2112,7 +2148,11 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(mockRequestOptions, '/api/v2/keys/{id}/actions/unsetKeyForDeletion', 'POST');
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/api/v2/keys/{id}/actions/unsetKeyForDeletion',
+          'POST'
+        );
         const expectedAccept = undefined;
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -2387,7 +2427,9 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const syncAssociatedResourcesResult = ibmKeyProtectApiService.syncAssociatedResources(syncAssociatedResourcesParams);
+        const syncAssociatedResourcesResult = ibmKeyProtectApiService.syncAssociatedResources(
+          syncAssociatedResourcesParams
+        );
 
         // all methods should return a Promise
         expectToBePromise(syncAssociatedResourcesResult);
@@ -2482,7 +2524,8 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const eventAcknowledgeResult = ibmKeyProtectApiService.eventAcknowledge(eventAcknowledgeParams);
+        const eventAcknowledgeResult =
+          ibmKeyProtectApiService.eventAcknowledge(eventAcknowledgeParams);
 
         // all methods should return a Promise
         expectToBePromise(eventAcknowledgeResult);
@@ -2864,7 +2907,9 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const getKeyCollectionMetadataResult = ibmKeyProtectApiService.getKeyCollectionMetadata(getKeyCollectionMetadataParams);
+        const getKeyCollectionMetadataResult = ibmKeyProtectApiService.getKeyCollectionMetadata(
+          getKeyCollectionMetadataParams
+        );
 
         // all methods should return a Promise
         expectToBePromise(getKeyCollectionMetadataResult);
@@ -3170,7 +3215,10 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const createKeyWithPoliciesOverridesResult = ibmKeyProtectApiService.createKeyWithPoliciesOverrides(createKeyWithPoliciesOverridesParams);
+        const createKeyWithPoliciesOverridesResult =
+          ibmKeyProtectApiService.createKeyWithPoliciesOverrides(
+            createKeyWithPoliciesOverridesParams
+          );
 
         // all methods should return a Promise
         expectToBePromise(createKeyWithPoliciesOverridesResult);
@@ -3221,7 +3269,9 @@ describe('IbmKeyProtectApiV2', () => {
           },
         };
 
-        ibmKeyProtectApiService.createKeyWithPoliciesOverrides(createKeyWithPoliciesOverridesParams);
+        ibmKeyProtectApiService.createKeyWithPoliciesOverrides(
+          createKeyWithPoliciesOverridesParams
+        );
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -4067,7 +4117,8 @@ describe('IbmKeyProtectApiV2', () => {
 
       // CreateMigrationIntentObject
       const createMigrationIntentObjectModel = {
-        targetCRK: 'crn:v1:bluemix:public:hs-crypto:<region>:<account-ID>:<instance-ID>:key:<key-ID>',
+        targetCRK:
+          'crn:v1:bluemix:public:hs-crypto:<region>:<account-ID>:<instance-ID>:key:<key-ID>',
       };
 
       function __createMigrationIntentTest() {
@@ -4087,7 +4138,9 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const createMigrationIntentResult = ibmKeyProtectApiService.createMigrationIntent(createMigrationIntentParams);
+        const createMigrationIntentResult = ibmKeyProtectApiService.createMigrationIntent(
+          createMigrationIntentParams
+        );
 
         // all methods should return a Promise
         expectToBePromise(createMigrationIntentResult);
@@ -4184,7 +4237,8 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const getMigrationIntentResult = ibmKeyProtectApiService.getMigrationIntent(getMigrationIntentParams);
+        const getMigrationIntentResult =
+          ibmKeyProtectApiService.getMigrationIntent(getMigrationIntentParams);
 
         // all methods should return a Promise
         expectToBePromise(getMigrationIntentResult);
@@ -4279,7 +4333,9 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const deleteMigrationIntentResult = ibmKeyProtectApiService.deleteMigrationIntent(deleteMigrationIntentParams);
+        const deleteMigrationIntentResult = ibmKeyProtectApiService.deleteMigrationIntent(
+          deleteMigrationIntentParams
+        );
 
         // all methods should return a Promise
         expectToBePromise(deleteMigrationIntentResult);
@@ -4631,7 +4687,8 @@ describe('IbmKeyProtectApiV2', () => {
           policy,
         };
 
-        const putInstancePolicyResult = ibmKeyProtectApiService.putInstancePolicy(putInstancePolicyParams);
+        const putInstancePolicyResult =
+          ibmKeyProtectApiService.putInstancePolicy(putInstancePolicyParams);
 
         // all methods should return a Promise
         expectToBePromise(putInstancePolicyResult);
@@ -4724,7 +4781,8 @@ describe('IbmKeyProtectApiV2', () => {
           policy,
         };
 
-        const getInstancePolicyResult = ibmKeyProtectApiService.getInstancePolicy(getInstancePolicyParams);
+        const getInstancePolicyResult =
+          ibmKeyProtectApiService.getInstancePolicy(getInstancePolicyParams);
 
         // all methods should return a Promise
         expectToBePromise(getInstancePolicyResult);
@@ -4812,7 +4870,8 @@ describe('IbmKeyProtectApiV2', () => {
           correlationId,
         };
 
-        const getAllowedIpPortResult = ibmKeyProtectApiService.getAllowedIpPort(getAllowedIpPortParams);
+        const getAllowedIpPortResult =
+          ibmKeyProtectApiService.getAllowedIpPort(getAllowedIpPortParams);
 
         // all methods should return a Promise
         expectToBePromise(getAllowedIpPortResult);
@@ -4908,7 +4967,8 @@ describe('IbmKeyProtectApiV2', () => {
       function __createRegistrationTest() {
         // Construct the params object for operation createRegistration
         const id = 'testString';
-        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn =
+          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const metadata = collectionMetadataModel;
         const resources = [createRegistrationResourceBodyModel];
@@ -4924,7 +4984,8 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const createRegistrationResult = ibmKeyProtectApiService.createRegistration(createRegistrationParams);
+        const createRegistrationResult =
+          ibmKeyProtectApiService.createRegistration(createRegistrationParams);
 
         // all methods should return a Promise
         expectToBePromise(createRegistrationResult);
@@ -4934,7 +4995,11 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(mockRequestOptions, '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}', 'POST');
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}',
+          'POST'
+        );
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -4965,7 +5030,8 @@ describe('IbmKeyProtectApiV2', () => {
       test('should prioritize user-given headers', () => {
         // parameters
         const id = 'testString';
-        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn =
+          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
@@ -5030,7 +5096,8 @@ describe('IbmKeyProtectApiV2', () => {
       function __updateRegistrationTest() {
         // Construct the params object for operation updateRegistration
         const id = 'testString';
-        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn =
+          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const metadata = collectionMetadataModel;
         const resources = [modifiableRegistrationResourceBodyModel];
@@ -5048,7 +5115,8 @@ describe('IbmKeyProtectApiV2', () => {
           ifMatch,
         };
 
-        const updateRegistrationResult = ibmKeyProtectApiService.updateRegistration(updateRegistrationParams);
+        const updateRegistrationResult =
+          ibmKeyProtectApiService.updateRegistration(updateRegistrationParams);
 
         // all methods should return a Promise
         expectToBePromise(updateRegistrationResult);
@@ -5058,7 +5126,11 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(mockRequestOptions, '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}', 'PATCH');
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}',
+          'PATCH'
+        );
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -5090,7 +5162,8 @@ describe('IbmKeyProtectApiV2', () => {
       test('should prioritize user-given headers', () => {
         // parameters
         const id = 'testString';
-        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn =
+          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
@@ -5155,7 +5228,8 @@ describe('IbmKeyProtectApiV2', () => {
       function __replaceRegistrationTest() {
         // Construct the params object for operation replaceRegistration
         const id = 'testString';
-        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn =
+          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const metadata = collectionMetadataModel;
         const resources = [replaceRegistrationResourceBodyModel];
@@ -5173,7 +5247,8 @@ describe('IbmKeyProtectApiV2', () => {
           ifMatch,
         };
 
-        const replaceRegistrationResult = ibmKeyProtectApiService.replaceRegistration(replaceRegistrationParams);
+        const replaceRegistrationResult =
+          ibmKeyProtectApiService.replaceRegistration(replaceRegistrationParams);
 
         // all methods should return a Promise
         expectToBePromise(replaceRegistrationResult);
@@ -5183,7 +5258,11 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(mockRequestOptions, '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}', 'PUT');
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}',
+          'PUT'
+        );
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -5215,7 +5294,8 @@ describe('IbmKeyProtectApiV2', () => {
       test('should prioritize user-given headers', () => {
         // parameters
         const id = 'testString';
-        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn =
+          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
@@ -5264,7 +5344,8 @@ describe('IbmKeyProtectApiV2', () => {
       function __deleteRegistrationTest() {
         // Construct the params object for operation deleteRegistration
         const id = 'testString';
-        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn =
+          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const correlationId = 'testString';
         const xKmsKeyRing = 'testString';
@@ -5278,7 +5359,8 @@ describe('IbmKeyProtectApiV2', () => {
           prefer,
         };
 
-        const deleteRegistrationResult = ibmKeyProtectApiService.deleteRegistration(deleteRegistrationParams);
+        const deleteRegistrationResult =
+          ibmKeyProtectApiService.deleteRegistration(deleteRegistrationParams);
 
         // all methods should return a Promise
         expectToBePromise(deleteRegistrationResult);
@@ -5288,7 +5370,11 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(mockRequestOptions, '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}', 'DELETE');
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}',
+          'DELETE'
+        );
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -5318,7 +5404,8 @@ describe('IbmKeyProtectApiV2', () => {
       test('should prioritize user-given headers', () => {
         // parameters
         const id = 'testString';
-        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn =
+          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
@@ -5374,7 +5461,8 @@ describe('IbmKeyProtectApiV2', () => {
 
       // CloudResourceName
       const cloudResourceNameModel = {
-        resourceCrn: 'crn:v1:bluemix:public:<service-name>:<location>:a/<account-id>:<service-instance>:<resource-type>:<resource>',
+        resourceCrn:
+          'crn:v1:bluemix:public:<service-name>:<location>:a/<account-id>:<service-instance>:<resource-type>:<resource>',
       };
 
       // RegistrationActionOneOfDeactivateRegistration
@@ -5402,7 +5490,9 @@ describe('IbmKeyProtectApiV2', () => {
           prefer,
         };
 
-        const actionOnRegistrationResult = ibmKeyProtectApiService.actionOnRegistration(actionOnRegistrationParams);
+        const actionOnRegistrationResult = ibmKeyProtectApiService.actionOnRegistration(
+          actionOnRegistrationParams
+        );
 
         // all methods should return a Promise
         expectToBePromise(actionOnRegistrationResult);
@@ -5499,7 +5589,8 @@ describe('IbmKeyProtectApiV2', () => {
         const xKmsKeyRing = 'testString';
         const limit = 200;
         const offset = 0;
-        const urlEncodedResourceCrnQuery = 'crn%3Av1%3Abluemix%3Apublic%3Adatabases-for-postgresql%3Aus-south%3Aa%2F00000000000000000000000000000000%3Afeddecaf-0000-0000-0000-1234567890ab%3A*%3A*';
+        const urlEncodedResourceCrnQuery =
+          'crn%3Av1%3Abluemix%3Apublic%3Adatabases-for-postgresql%3Aus-south%3Aa%2F00000000000000000000000000000000%3Afeddecaf-0000-0000-0000-1234567890ab%3A*%3A*';
         const preventKeyDeletion = true;
         const totalCount = true;
         const getRegistrationsParams = {
@@ -5514,7 +5605,8 @@ describe('IbmKeyProtectApiV2', () => {
           totalCount,
         };
 
-        const getRegistrationsResult = ibmKeyProtectApiService.getRegistrations(getRegistrationsParams);
+        const getRegistrationsResult =
+          ibmKeyProtectApiService.getRegistrations(getRegistrationsParams);
 
         // all methods should return a Promise
         expectToBePromise(getRegistrationsResult);
@@ -5533,7 +5625,9 @@ describe('IbmKeyProtectApiV2', () => {
         checkUserHeader(createRequestMock, 'X-Kms-Key-Ring', xKmsKeyRing);
         expect(mockRequestOptions.qs.limit).toEqual(limit);
         expect(mockRequestOptions.qs.offset).toEqual(offset);
-        expect(mockRequestOptions.qs.urlEncodedResourceCRNQuery).toEqual(urlEncodedResourceCrnQuery);
+        expect(mockRequestOptions.qs.urlEncodedResourceCRNQuery).toEqual(
+          urlEncodedResourceCrnQuery
+        );
         expect(mockRequestOptions.qs.preventKeyDeletion).toEqual(preventKeyDeletion);
         expect(mockRequestOptions.qs.totalCount).toEqual(totalCount);
         expect(mockRequestOptions.path.id).toEqual(id);
@@ -5606,7 +5700,8 @@ describe('IbmKeyProtectApiV2', () => {
         const bluemixInstance = 'testString';
         const correlationId = 'testString';
         const xKmsKeyRing = 'testString';
-        const urlEncodedResourceCrnQuery = 'crn%3Av1%3Abluemix%3Apublic%3Adatabases-for-postgresql%3Aus-south%3Aa%2F00000000000000000000000000000000%3Afeddecaf-0000-0000-0000-1234567890ab%3A*%3A*';
+        const urlEncodedResourceCrnQuery =
+          'crn%3Av1%3Abluemix%3Apublic%3Adatabases-for-postgresql%3Aus-south%3Aa%2F00000000000000000000000000000000%3Afeddecaf-0000-0000-0000-1234567890ab%3A*%3A*';
         const limit = 200;
         const offset = 0;
         const preventKeyDeletion = true;
@@ -5622,7 +5717,9 @@ describe('IbmKeyProtectApiV2', () => {
           totalCount,
         };
 
-        const getRegistrationsAllKeysResult = ibmKeyProtectApiService.getRegistrationsAllKeys(getRegistrationsAllKeysParams);
+        const getRegistrationsAllKeysResult = ibmKeyProtectApiService.getRegistrationsAllKeys(
+          getRegistrationsAllKeysParams
+        );
 
         // all methods should return a Promise
         expectToBePromise(getRegistrationsAllKeysResult);
@@ -5639,7 +5736,9 @@ describe('IbmKeyProtectApiV2', () => {
         checkUserHeader(createRequestMock, 'Bluemix-Instance', bluemixInstance);
         checkUserHeader(createRequestMock, 'Correlation-Id', correlationId);
         checkUserHeader(createRequestMock, 'X-Kms-Key-Ring', xKmsKeyRing);
-        expect(mockRequestOptions.qs.urlEncodedResourceCRNQuery).toEqual(urlEncodedResourceCrnQuery);
+        expect(mockRequestOptions.qs.urlEncodedResourceCRNQuery).toEqual(
+          urlEncodedResourceCrnQuery
+        );
         expect(mockRequestOptions.qs.limit).toEqual(limit);
         expect(mockRequestOptions.qs.offset).toEqual(offset);
         expect(mockRequestOptions.qs.preventKeyDeletion).toEqual(preventKeyDeletion);

--- a/test/unit/ibm-key-protect-api.v2.unit.test.js
+++ b/test/unit/ibm-key-protect-api.v2.unit.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2023.
+ * (C) Copyright IBM Corp. 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,13 @@ const sdkCorePackage = require('ibm-cloud-sdk-core');
 const { NoAuthAuthenticator, unitTestUtils } = sdkCorePackage;
 const IbmKeyProtectApiV2 = require('../../dist/ibm-key-protect-api/v2');
 
-const { getOptions, checkUrlAndMethod, checkMediaHeaders, expectToBePromise, checkUserHeader } =
-  unitTestUtils;
+const {
+  getOptions,
+  checkUrlAndMethod,
+  checkMediaHeaders,
+  expectToBePromise,
+  checkUserHeader,
+} = unitTestUtils;
 
 const ibmKeyProtectApiServiceOptions = {
   authenticator: new NoAuthAuthenticator(),
@@ -344,8 +349,7 @@ describe('IbmKeyProtectApiV2', () => {
           instanceId,
         };
 
-        const cryptoV2GetInstanceEndpointsResult =
-          ibmKeyProtectApiService.cryptoV2GetInstanceEndpoints(cryptoV2GetInstanceEndpointsParams);
+        const cryptoV2GetInstanceEndpointsResult = ibmKeyProtectApiService.cryptoV2GetInstanceEndpoints(cryptoV2GetInstanceEndpointsParams);
 
         // all methods should return a Promise
         expectToBePromise(cryptoV2GetInstanceEndpointsResult);
@@ -443,8 +447,7 @@ describe('IbmKeyProtectApiV2', () => {
           offset,
         };
 
-        const getGovernanceConfigResult =
-          ibmKeyProtectApiService.getGovernanceConfig(getGovernanceConfigParams);
+        const getGovernanceConfigResult = ibmKeyProtectApiService.getGovernanceConfig(getGovernanceConfigParams);
 
         // all methods should return a Promise
         expectToBePromise(getGovernanceConfigResult);
@@ -543,7 +546,7 @@ describe('IbmKeyProtectApiV2', () => {
 
       beforeEach(() => {
         unmock_createRequest();
-        nock(serviceUrl)
+        const scope = nock(serviceUrl)
           .get((uri) => uri.includes(path))
           .reply(200, mockPagerResponse1)
           .get((uri) => uri.includes(path))
@@ -566,10 +569,7 @@ describe('IbmKeyProtectApiV2', () => {
           limit: 10,
         };
         const allResults = [];
-        const pager = new IbmKeyProtectApiV2.GetGovernanceConfigPager(
-          ibmKeyProtectApiService,
-          params
-        );
+        const pager = new IbmKeyProtectApiV2.GetGovernanceConfigPager(ibmKeyProtectApiService, params);
         while (pager.hasNext()) {
           const nextPage = await pager.getNext();
           expect(nextPage).not.toBeNull();
@@ -589,10 +589,7 @@ describe('IbmKeyProtectApiV2', () => {
           transactionId: 'testString',
           limit: 10,
         };
-        const pager = new IbmKeyProtectApiV2.GetGovernanceConfigPager(
-          ibmKeyProtectApiService,
-          params
-        );
+        const pager = new IbmKeyProtectApiV2.GetGovernanceConfigPager(ibmKeyProtectApiService, params);
         const allResults = await pager.getAll();
         expect(allResults).not.toBeNull();
         expect(allResults).toHaveLength(2);
@@ -617,8 +614,7 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const postImportTokenResult =
-          ibmKeyProtectApiService.postImportToken(postImportTokenParams);
+        const postImportTokenResult = ibmKeyProtectApiService.postImportToken(postImportTokenParams);
 
         // all methods should return a Promise
         expectToBePromise(postImportTokenResult);
@@ -778,6 +774,816 @@ describe('IbmKeyProtectApiV2', () => {
         let err;
         try {
           await ibmKeyProtectApiService.getImportToken();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('getKmipAdapters', () => {
+    describe('positive tests', () => {
+      function __getKmipAdaptersTest() {
+        // Construct the params object for operation getKmipAdapters
+        const bluemixInstance = 'testString';
+        const correlationId = 'testString';
+        const limit = 100;
+        const offset = 0;
+        const totalCount = true;
+        const getKmipAdaptersParams = {
+          bluemixInstance,
+          correlationId,
+          limit,
+          offset,
+          totalCount,
+        };
+
+        const getKmipAdaptersResult = ibmKeyProtectApiService.getKmipAdapters(getKmipAdaptersParams);
+
+        // all methods should return a Promise
+        expectToBePromise(getKmipAdaptersResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/api/v2/kmip_adapters', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'Bluemix-Instance', bluemixInstance);
+        checkUserHeader(createRequestMock, 'Correlation-Id', correlationId);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs.offset).toEqual(offset);
+        expect(mockRequestOptions.qs.totalCount).toEqual(totalCount);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getKmipAdaptersTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.enableRetries();
+        __getKmipAdaptersTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.disableRetries();
+        __getKmipAdaptersTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const bluemixInstance = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getKmipAdaptersParams = {
+          bluemixInstance,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        ibmKeyProtectApiService.getKmipAdapters(getKmipAdaptersParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.getKmipAdapters({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.getKmipAdapters();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('createKmipAdapter', () => {
+    describe('positive tests', () => {
+      // Request models needed by this operation.
+
+      // CollectionMetadata
+      const collectionMetadataModel = {
+        collectionType: 'application/vnd.ibm.kms.kmip_adapter+json',
+        collectionTotal: 1,
+      };
+
+      // KMIPProfileDataBodyKMIPProfileDataNative
+      const kmipProfileDataBodyModel = {
+        crk_id: 'feddecaf-0000-0000-0000-1234567890ab',
+        target_key_ring_id: 'testString',
+      };
+
+      // CreateKMIPAdapterRequestBodyResourcesItem
+      const createKmipAdapterRequestBodyResourcesItemModel = {
+        name: 'kmip-adapter-name',
+        description: 'kmip adapter description',
+        profile: 'native_1.0',
+        profile_data: kmipProfileDataBodyModel,
+      };
+
+      function __createKmipAdapterTest() {
+        // Construct the params object for operation createKmipAdapter
+        const bluemixInstance = 'testString';
+        const metadata = collectionMetadataModel;
+        const resources = [createKmipAdapterRequestBodyResourcesItemModel];
+        const correlationId = 'testString';
+        const createKmipAdapterParams = {
+          bluemixInstance,
+          metadata,
+          resources,
+          correlationId,
+        };
+
+        const createKmipAdapterResult = ibmKeyProtectApiService.createKmipAdapter(createKmipAdapterParams);
+
+        // all methods should return a Promise
+        expectToBePromise(createKmipAdapterResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/api/v2/kmip_adapters', 'POST');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'Bluemix-Instance', bluemixInstance);
+        checkUserHeader(createRequestMock, 'Correlation-Id', correlationId);
+        expect(mockRequestOptions.body.metadata).toEqual(metadata);
+        expect(mockRequestOptions.body.resources).toEqual(resources);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __createKmipAdapterTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.enableRetries();
+        __createKmipAdapterTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.disableRetries();
+        __createKmipAdapterTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const bluemixInstance = 'testString';
+        const metadata = collectionMetadataModel;
+        const resources = [createKmipAdapterRequestBodyResourcesItemModel];
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const createKmipAdapterParams = {
+          bluemixInstance,
+          metadata,
+          resources,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        ibmKeyProtectApiService.createKmipAdapter(createKmipAdapterParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.createKmipAdapter({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.createKmipAdapter();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('getKmipAdapter', () => {
+    describe('positive tests', () => {
+      function __getKmipAdapterTest() {
+        // Construct the params object for operation getKmipAdapter
+        const bluemixInstance = 'testString';
+        const id = 'testString';
+        const correlationId = 'testString';
+        const getKmipAdapterParams = {
+          bluemixInstance,
+          id,
+          correlationId,
+        };
+
+        const getKmipAdapterResult = ibmKeyProtectApiService.getKmipAdapter(getKmipAdapterParams);
+
+        // all methods should return a Promise
+        expectToBePromise(getKmipAdapterResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/api/v2/kmip_adapters/{id}', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'Bluemix-Instance', bluemixInstance);
+        checkUserHeader(createRequestMock, 'Correlation-Id', correlationId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getKmipAdapterTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.enableRetries();
+        __getKmipAdapterTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.disableRetries();
+        __getKmipAdapterTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const bluemixInstance = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getKmipAdapterParams = {
+          bluemixInstance,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        ibmKeyProtectApiService.getKmipAdapter(getKmipAdapterParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.getKmipAdapter({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.getKmipAdapter();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('deleteKmipAdapter', () => {
+    describe('positive tests', () => {
+      function __deleteKmipAdapterTest() {
+        // Construct the params object for operation deleteKmipAdapter
+        const bluemixInstance = 'testString';
+        const id = 'testString';
+        const correlationId = 'testString';
+        const deleteKmipAdapterParams = {
+          bluemixInstance,
+          id,
+          correlationId,
+        };
+
+        const deleteKmipAdapterResult = ibmKeyProtectApiService.deleteKmipAdapter(deleteKmipAdapterParams);
+
+        // all methods should return a Promise
+        expectToBePromise(deleteKmipAdapterResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/api/v2/kmip_adapters/{id}', 'DELETE');
+        const expectedAccept = undefined;
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'Bluemix-Instance', bluemixInstance);
+        checkUserHeader(createRequestMock, 'Correlation-Id', correlationId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteKmipAdapterTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.enableRetries();
+        __deleteKmipAdapterTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.disableRetries();
+        __deleteKmipAdapterTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const bluemixInstance = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const deleteKmipAdapterParams = {
+          bluemixInstance,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        ibmKeyProtectApiService.deleteKmipAdapter(deleteKmipAdapterParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.deleteKmipAdapter({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.deleteKmipAdapter();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('getKmipClientCertificates', () => {
+    describe('positive tests', () => {
+      function __getKmipClientCertificatesTest() {
+        // Construct the params object for operation getKmipClientCertificates
+        const bluemixInstance = 'testString';
+        const adapterId = 'testString';
+        const correlationId = 'testString';
+        const limit = 100;
+        const offset = 0;
+        const totalCount = true;
+        const getKmipClientCertificatesParams = {
+          bluemixInstance,
+          adapterId,
+          correlationId,
+          limit,
+          offset,
+          totalCount,
+        };
+
+        const getKmipClientCertificatesResult = ibmKeyProtectApiService.getKmipClientCertificates(getKmipClientCertificatesParams);
+
+        // all methods should return a Promise
+        expectToBePromise(getKmipClientCertificatesResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/api/v2/kmip_adapters/{adapter_id}/certificates', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'Bluemix-Instance', bluemixInstance);
+        checkUserHeader(createRequestMock, 'Correlation-Id', correlationId);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs.offset).toEqual(offset);
+        expect(mockRequestOptions.qs.totalCount).toEqual(totalCount);
+        expect(mockRequestOptions.path.adapter_id).toEqual(adapterId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getKmipClientCertificatesTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.enableRetries();
+        __getKmipClientCertificatesTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.disableRetries();
+        __getKmipClientCertificatesTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const bluemixInstance = 'testString';
+        const adapterId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getKmipClientCertificatesParams = {
+          bluemixInstance,
+          adapterId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        ibmKeyProtectApiService.getKmipClientCertificates(getKmipClientCertificatesParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.getKmipClientCertificates({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.getKmipClientCertificates();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('addKmipClientCertificate', () => {
+    describe('positive tests', () => {
+      // Request models needed by this operation.
+
+      // CollectionMetadata
+      const collectionMetadataModel = {
+        collectionType: 'application/vnd.ibm.kms.kmip_adapter_certificate+json',
+        collectionTotal: 1,
+      };
+
+      // CreateKMIPClientCertificateObject
+      const createKmipClientCertificateObjectModel = {
+        certificate: 'testString',
+        name: 'testString',
+      };
+
+      function __addKmipClientCertificateTest() {
+        // Construct the params object for operation addKmipClientCertificate
+        const bluemixInstance = 'testString';
+        const adapterId = 'testString';
+        const metadata = collectionMetadataModel;
+        const resources = [createKmipClientCertificateObjectModel];
+        const correlationId = 'testString';
+        const addKmipClientCertificateParams = {
+          bluemixInstance,
+          adapterId,
+          metadata,
+          resources,
+          correlationId,
+        };
+
+        const addKmipClientCertificateResult = ibmKeyProtectApiService.addKmipClientCertificate(addKmipClientCertificateParams);
+
+        // all methods should return a Promise
+        expectToBePromise(addKmipClientCertificateResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/api/v2/kmip_adapters/{adapter_id}/certificates', 'POST');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'Bluemix-Instance', bluemixInstance);
+        checkUserHeader(createRequestMock, 'Correlation-Id', correlationId);
+        expect(mockRequestOptions.body.metadata).toEqual(metadata);
+        expect(mockRequestOptions.body.resources).toEqual(resources);
+        expect(mockRequestOptions.path.adapter_id).toEqual(adapterId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __addKmipClientCertificateTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.enableRetries();
+        __addKmipClientCertificateTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.disableRetries();
+        __addKmipClientCertificateTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const bluemixInstance = 'testString';
+        const adapterId = 'testString';
+        const metadata = collectionMetadataModel;
+        const resources = [createKmipClientCertificateObjectModel];
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const addKmipClientCertificateParams = {
+          bluemixInstance,
+          adapterId,
+          metadata,
+          resources,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        ibmKeyProtectApiService.addKmipClientCertificate(addKmipClientCertificateParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.addKmipClientCertificate({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.addKmipClientCertificate();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('getKmipClientCertificate', () => {
+    describe('positive tests', () => {
+      function __getKmipClientCertificateTest() {
+        // Construct the params object for operation getKmipClientCertificate
+        const bluemixInstance = 'testString';
+        const adapterId = 'testString';
+        const id = 'testString';
+        const correlationId = 'testString';
+        const getKmipClientCertificateParams = {
+          bluemixInstance,
+          adapterId,
+          id,
+          correlationId,
+        };
+
+        const getKmipClientCertificateResult = ibmKeyProtectApiService.getKmipClientCertificate(getKmipClientCertificateParams);
+
+        // all methods should return a Promise
+        expectToBePromise(getKmipClientCertificateResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/api/v2/kmip_adapters/{adapter_id}/certificates/{id}', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'Bluemix-Instance', bluemixInstance);
+        checkUserHeader(createRequestMock, 'Correlation-Id', correlationId);
+        expect(mockRequestOptions.path.adapter_id).toEqual(adapterId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getKmipClientCertificateTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.enableRetries();
+        __getKmipClientCertificateTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.disableRetries();
+        __getKmipClientCertificateTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const bluemixInstance = 'testString';
+        const adapterId = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getKmipClientCertificateParams = {
+          bluemixInstance,
+          adapterId,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        ibmKeyProtectApiService.getKmipClientCertificate(getKmipClientCertificateParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.getKmipClientCertificate({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.getKmipClientCertificate();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('deleteKmipClientCertificate', () => {
+    describe('positive tests', () => {
+      function __deleteKmipClientCertificateTest() {
+        // Construct the params object for operation deleteKmipClientCertificate
+        const bluemixInstance = 'testString';
+        const adapterId = 'testString';
+        const id = 'testString';
+        const correlationId = 'testString';
+        const deleteKmipClientCertificateParams = {
+          bluemixInstance,
+          adapterId,
+          id,
+          correlationId,
+        };
+
+        const deleteKmipClientCertificateResult = ibmKeyProtectApiService.deleteKmipClientCertificate(deleteKmipClientCertificateParams);
+
+        // all methods should return a Promise
+        expectToBePromise(deleteKmipClientCertificateResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/api/v2/kmip_adapters/{adapter_id}/certificates/{id}', 'DELETE');
+        const expectedAccept = undefined;
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'Bluemix-Instance', bluemixInstance);
+        checkUserHeader(createRequestMock, 'Correlation-Id', correlationId);
+        expect(mockRequestOptions.path.adapter_id).toEqual(adapterId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteKmipClientCertificateTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.enableRetries();
+        __deleteKmipClientCertificateTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        ibmKeyProtectApiService.disableRetries();
+        __deleteKmipClientCertificateTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const bluemixInstance = 'testString';
+        const adapterId = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const deleteKmipClientCertificateParams = {
+          bluemixInstance,
+          adapterId,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        ibmKeyProtectApiService.deleteKmipClientCertificate(deleteKmipClientCertificateParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.deleteKmipClientCertificate({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await ibmKeyProtectApiService.deleteKmipClientCertificate();
         } catch (e) {
           err = e;
         }
@@ -1201,8 +2007,7 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const setKeyForDeletionResult =
-          ibmKeyProtectApiService.setKeyForDeletion(setKeyForDeletionParams);
+        const setKeyForDeletionResult = ibmKeyProtectApiService.setKeyForDeletion(setKeyForDeletionParams);
 
         // all methods should return a Promise
         expectToBePromise(setKeyForDeletionResult);
@@ -1212,11 +2017,7 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/api/v2/keys/{id}/actions/setKeyForDeletion',
-          'POST'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/api/v2/keys/{id}/actions/setKeyForDeletion', 'POST');
         const expectedAccept = undefined;
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -1301,8 +2102,7 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const unsetKeyForDeletionResult =
-          ibmKeyProtectApiService.unsetKeyForDeletion(unsetKeyForDeletionParams);
+        const unsetKeyForDeletionResult = ibmKeyProtectApiService.unsetKeyForDeletion(unsetKeyForDeletionParams);
 
         // all methods should return a Promise
         expectToBePromise(unsetKeyForDeletionResult);
@@ -1312,11 +2112,7 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/api/v2/keys/{id}/actions/unsetKeyForDeletion',
-          'POST'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/api/v2/keys/{id}/actions/unsetKeyForDeletion', 'POST');
         const expectedAccept = undefined;
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -1591,9 +2387,7 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const syncAssociatedResourcesResult = ibmKeyProtectApiService.syncAssociatedResources(
-          syncAssociatedResourcesParams
-        );
+        const syncAssociatedResourcesResult = ibmKeyProtectApiService.syncAssociatedResources(syncAssociatedResourcesParams);
 
         // all methods should return a Promise
         expectToBePromise(syncAssociatedResourcesResult);
@@ -1688,8 +2482,7 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const eventAcknowledgeResult =
-          ibmKeyProtectApiService.eventAcknowledge(eventAcknowledgeParams);
+        const eventAcknowledgeResult = ibmKeyProtectApiService.eventAcknowledge(eventAcknowledgeParams);
 
         // all methods should return a Promise
         expectToBePromise(eventAcknowledgeResult);
@@ -2071,9 +2864,7 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const getKeyCollectionMetadataResult = ibmKeyProtectApiService.getKeyCollectionMetadata(
-          getKeyCollectionMetadataParams
-        );
+        const getKeyCollectionMetadataResult = ibmKeyProtectApiService.getKeyCollectionMetadata(getKeyCollectionMetadataParams);
 
         // all methods should return a Promise
         expectToBePromise(getKeyCollectionMetadataResult);
@@ -2379,10 +3170,7 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const createKeyWithPoliciesOverridesResult =
-          ibmKeyProtectApiService.createKeyWithPoliciesOverrides(
-            createKeyWithPoliciesOverridesParams
-          );
+        const createKeyWithPoliciesOverridesResult = ibmKeyProtectApiService.createKeyWithPoliciesOverrides(createKeyWithPoliciesOverridesParams);
 
         // all methods should return a Promise
         expectToBePromise(createKeyWithPoliciesOverridesResult);
@@ -2433,9 +3221,7 @@ describe('IbmKeyProtectApiV2', () => {
           },
         };
 
-        ibmKeyProtectApiService.createKeyWithPoliciesOverrides(
-          createKeyWithPoliciesOverridesParams
-        );
+        ibmKeyProtectApiService.createKeyWithPoliciesOverrides(createKeyWithPoliciesOverridesParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -3281,8 +4067,7 @@ describe('IbmKeyProtectApiV2', () => {
 
       // CreateMigrationIntentObject
       const createMigrationIntentObjectModel = {
-        targetCRK:
-          'crn:v1:bluemix:public:hs-crypto:<region>:<account-ID>:<instance-ID>:key:<key-ID>',
+        targetCRK: 'crn:v1:bluemix:public:hs-crypto:<region>:<account-ID>:<instance-ID>:key:<key-ID>',
       };
 
       function __createMigrationIntentTest() {
@@ -3302,9 +4087,7 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const createMigrationIntentResult = ibmKeyProtectApiService.createMigrationIntent(
-          createMigrationIntentParams
-        );
+        const createMigrationIntentResult = ibmKeyProtectApiService.createMigrationIntent(createMigrationIntentParams);
 
         // all methods should return a Promise
         expectToBePromise(createMigrationIntentResult);
@@ -3401,8 +4184,7 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const getMigrationIntentResult =
-          ibmKeyProtectApiService.getMigrationIntent(getMigrationIntentParams);
+        const getMigrationIntentResult = ibmKeyProtectApiService.getMigrationIntent(getMigrationIntentParams);
 
         // all methods should return a Promise
         expectToBePromise(getMigrationIntentResult);
@@ -3497,9 +4279,7 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const deleteMigrationIntentResult = ibmKeyProtectApiService.deleteMigrationIntent(
-          deleteMigrationIntentParams
-        );
+        const deleteMigrationIntentResult = ibmKeyProtectApiService.deleteMigrationIntent(deleteMigrationIntentParams);
 
         // all methods should return a Promise
         expectToBePromise(deleteMigrationIntentResult);
@@ -3851,8 +4631,7 @@ describe('IbmKeyProtectApiV2', () => {
           policy,
         };
 
-        const putInstancePolicyResult =
-          ibmKeyProtectApiService.putInstancePolicy(putInstancePolicyParams);
+        const putInstancePolicyResult = ibmKeyProtectApiService.putInstancePolicy(putInstancePolicyParams);
 
         // all methods should return a Promise
         expectToBePromise(putInstancePolicyResult);
@@ -3945,8 +4724,7 @@ describe('IbmKeyProtectApiV2', () => {
           policy,
         };
 
-        const getInstancePolicyResult =
-          ibmKeyProtectApiService.getInstancePolicy(getInstancePolicyParams);
+        const getInstancePolicyResult = ibmKeyProtectApiService.getInstancePolicy(getInstancePolicyParams);
 
         // all methods should return a Promise
         expectToBePromise(getInstancePolicyResult);
@@ -4034,8 +4812,7 @@ describe('IbmKeyProtectApiV2', () => {
           correlationId,
         };
 
-        const getAllowedIpPortResult =
-          ibmKeyProtectApiService.getAllowedIpPort(getAllowedIpPortParams);
+        const getAllowedIpPortResult = ibmKeyProtectApiService.getAllowedIpPort(getAllowedIpPortParams);
 
         // all methods should return a Promise
         expectToBePromise(getAllowedIpPortResult);
@@ -4131,8 +4908,7 @@ describe('IbmKeyProtectApiV2', () => {
       function __createRegistrationTest() {
         // Construct the params object for operation createRegistration
         const id = 'testString';
-        const urlEncodedResourceCrn =
-          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const metadata = collectionMetadataModel;
         const resources = [createRegistrationResourceBodyModel];
@@ -4148,8 +4924,7 @@ describe('IbmKeyProtectApiV2', () => {
           xKmsKeyRing,
         };
 
-        const createRegistrationResult =
-          ibmKeyProtectApiService.createRegistration(createRegistrationParams);
+        const createRegistrationResult = ibmKeyProtectApiService.createRegistration(createRegistrationParams);
 
         // all methods should return a Promise
         expectToBePromise(createRegistrationResult);
@@ -4159,11 +4934,7 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}',
-          'POST'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}', 'POST');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -4194,8 +4965,7 @@ describe('IbmKeyProtectApiV2', () => {
       test('should prioritize user-given headers', () => {
         // parameters
         const id = 'testString';
-        const urlEncodedResourceCrn =
-          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
@@ -4260,8 +5030,7 @@ describe('IbmKeyProtectApiV2', () => {
       function __updateRegistrationTest() {
         // Construct the params object for operation updateRegistration
         const id = 'testString';
-        const urlEncodedResourceCrn =
-          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const metadata = collectionMetadataModel;
         const resources = [modifiableRegistrationResourceBodyModel];
@@ -4279,8 +5048,7 @@ describe('IbmKeyProtectApiV2', () => {
           ifMatch,
         };
 
-        const updateRegistrationResult =
-          ibmKeyProtectApiService.updateRegistration(updateRegistrationParams);
+        const updateRegistrationResult = ibmKeyProtectApiService.updateRegistration(updateRegistrationParams);
 
         // all methods should return a Promise
         expectToBePromise(updateRegistrationResult);
@@ -4290,11 +5058,7 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}',
-          'PATCH'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}', 'PATCH');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -4326,8 +5090,7 @@ describe('IbmKeyProtectApiV2', () => {
       test('should prioritize user-given headers', () => {
         // parameters
         const id = 'testString';
-        const urlEncodedResourceCrn =
-          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
@@ -4392,8 +5155,7 @@ describe('IbmKeyProtectApiV2', () => {
       function __replaceRegistrationTest() {
         // Construct the params object for operation replaceRegistration
         const id = 'testString';
-        const urlEncodedResourceCrn =
-          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const metadata = collectionMetadataModel;
         const resources = [replaceRegistrationResourceBodyModel];
@@ -4411,8 +5173,7 @@ describe('IbmKeyProtectApiV2', () => {
           ifMatch,
         };
 
-        const replaceRegistrationResult =
-          ibmKeyProtectApiService.replaceRegistration(replaceRegistrationParams);
+        const replaceRegistrationResult = ibmKeyProtectApiService.replaceRegistration(replaceRegistrationParams);
 
         // all methods should return a Promise
         expectToBePromise(replaceRegistrationResult);
@@ -4422,11 +5183,7 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}',
-          'PUT'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}', 'PUT');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -4458,8 +5215,7 @@ describe('IbmKeyProtectApiV2', () => {
       test('should prioritize user-given headers', () => {
         // parameters
         const id = 'testString';
-        const urlEncodedResourceCrn =
-          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
@@ -4508,8 +5264,7 @@ describe('IbmKeyProtectApiV2', () => {
       function __deleteRegistrationTest() {
         // Construct the params object for operation deleteRegistration
         const id = 'testString';
-        const urlEncodedResourceCrn =
-          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const correlationId = 'testString';
         const xKmsKeyRing = 'testString';
@@ -4523,8 +5278,7 @@ describe('IbmKeyProtectApiV2', () => {
           prefer,
         };
 
-        const deleteRegistrationResult =
-          ibmKeyProtectApiService.deleteRegistration(deleteRegistrationParams);
+        const deleteRegistrationResult = ibmKeyProtectApiService.deleteRegistration(deleteRegistrationParams);
 
         // all methods should return a Promise
         expectToBePromise(deleteRegistrationResult);
@@ -4534,11 +5288,7 @@ describe('IbmKeyProtectApiV2', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}',
-          'DELETE'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/api/v2/keys/{id}/registrations/{urlEncodedResourceCRN}', 'DELETE');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -4568,8 +5318,7 @@ describe('IbmKeyProtectApiV2', () => {
       test('should prioritize user-given headers', () => {
         // parameters
         const id = 'testString';
-        const urlEncodedResourceCrn =
-          'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
+        const urlEncodedResourceCrn = 'crn%3av1%3abluemix%3apublic%3acloud-object-storage%3aglobal%3aa%2f00000000000000000000000000000000%3afeddecaf-0000-0000-0000-1234567890ab%3a%3abucket';
         const bluemixInstance = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
@@ -4625,8 +5374,7 @@ describe('IbmKeyProtectApiV2', () => {
 
       // CloudResourceName
       const cloudResourceNameModel = {
-        resourceCrn:
-          'crn:v1:bluemix:public:<service-name>:<location>:a/<account-id>:<service-instance>:<resource-type>:<resource>',
+        resourceCrn: 'crn:v1:bluemix:public:<service-name>:<location>:a/<account-id>:<service-instance>:<resource-type>:<resource>',
       };
 
       // RegistrationActionOneOfDeactivateRegistration
@@ -4654,9 +5402,7 @@ describe('IbmKeyProtectApiV2', () => {
           prefer,
         };
 
-        const actionOnRegistrationResult = ibmKeyProtectApiService.actionOnRegistration(
-          actionOnRegistrationParams
-        );
+        const actionOnRegistrationResult = ibmKeyProtectApiService.actionOnRegistration(actionOnRegistrationParams);
 
         // all methods should return a Promise
         expectToBePromise(actionOnRegistrationResult);
@@ -4753,8 +5499,7 @@ describe('IbmKeyProtectApiV2', () => {
         const xKmsKeyRing = 'testString';
         const limit = 200;
         const offset = 0;
-        const urlEncodedResourceCrnQuery =
-          'crn%3Av1%3Abluemix%3Apublic%3Adatabases-for-postgresql%3Aus-south%3Aa%2F00000000000000000000000000000000%3Afeddecaf-0000-0000-0000-1234567890ab%3A*%3A*';
+        const urlEncodedResourceCrnQuery = 'crn%3Av1%3Abluemix%3Apublic%3Adatabases-for-postgresql%3Aus-south%3Aa%2F00000000000000000000000000000000%3Afeddecaf-0000-0000-0000-1234567890ab%3A*%3A*';
         const preventKeyDeletion = true;
         const totalCount = true;
         const getRegistrationsParams = {
@@ -4769,8 +5514,7 @@ describe('IbmKeyProtectApiV2', () => {
           totalCount,
         };
 
-        const getRegistrationsResult =
-          ibmKeyProtectApiService.getRegistrations(getRegistrationsParams);
+        const getRegistrationsResult = ibmKeyProtectApiService.getRegistrations(getRegistrationsParams);
 
         // all methods should return a Promise
         expectToBePromise(getRegistrationsResult);
@@ -4789,9 +5533,7 @@ describe('IbmKeyProtectApiV2', () => {
         checkUserHeader(createRequestMock, 'X-Kms-Key-Ring', xKmsKeyRing);
         expect(mockRequestOptions.qs.limit).toEqual(limit);
         expect(mockRequestOptions.qs.offset).toEqual(offset);
-        expect(mockRequestOptions.qs.urlEncodedResourceCRNQuery).toEqual(
-          urlEncodedResourceCrnQuery
-        );
+        expect(mockRequestOptions.qs.urlEncodedResourceCRNQuery).toEqual(urlEncodedResourceCrnQuery);
         expect(mockRequestOptions.qs.preventKeyDeletion).toEqual(preventKeyDeletion);
         expect(mockRequestOptions.qs.totalCount).toEqual(totalCount);
         expect(mockRequestOptions.path.id).toEqual(id);
@@ -4864,8 +5606,7 @@ describe('IbmKeyProtectApiV2', () => {
         const bluemixInstance = 'testString';
         const correlationId = 'testString';
         const xKmsKeyRing = 'testString';
-        const urlEncodedResourceCrnQuery =
-          'crn%3Av1%3Abluemix%3Apublic%3Adatabases-for-postgresql%3Aus-south%3Aa%2F00000000000000000000000000000000%3Afeddecaf-0000-0000-0000-1234567890ab%3A*%3A*';
+        const urlEncodedResourceCrnQuery = 'crn%3Av1%3Abluemix%3Apublic%3Adatabases-for-postgresql%3Aus-south%3Aa%2F00000000000000000000000000000000%3Afeddecaf-0000-0000-0000-1234567890ab%3A*%3A*';
         const limit = 200;
         const offset = 0;
         const preventKeyDeletion = true;
@@ -4881,9 +5622,7 @@ describe('IbmKeyProtectApiV2', () => {
           totalCount,
         };
 
-        const getRegistrationsAllKeysResult = ibmKeyProtectApiService.getRegistrationsAllKeys(
-          getRegistrationsAllKeysParams
-        );
+        const getRegistrationsAllKeysResult = ibmKeyProtectApiService.getRegistrationsAllKeys(getRegistrationsAllKeysParams);
 
         // all methods should return a Promise
         expectToBePromise(getRegistrationsAllKeysResult);
@@ -4900,9 +5639,7 @@ describe('IbmKeyProtectApiV2', () => {
         checkUserHeader(createRequestMock, 'Bluemix-Instance', bluemixInstance);
         checkUserHeader(createRequestMock, 'Correlation-Id', correlationId);
         checkUserHeader(createRequestMock, 'X-Kms-Key-Ring', xKmsKeyRing);
-        expect(mockRequestOptions.qs.urlEncodedResourceCRNQuery).toEqual(
-          urlEncodedResourceCrnQuery
-        );
+        expect(mockRequestOptions.qs.urlEncodedResourceCRNQuery).toEqual(urlEncodedResourceCrnQuery);
         expect(mockRequestOptions.qs.limit).toEqual(limit);
         expect(mockRequestOptions.qs.offset).toEqual(offset);
         expect(mockRequestOptions.qs.preventKeyDeletion).toEqual(preventKeyDeletion);


### PR DESCRIPTION
Code and unit tests were automatically generated by `openapi-sdkgen`, and then linting issues were fixed.